### PR TITLE
メール認証文言変更-アカウント登録完了

### DIFF
--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,0 +1,29 @@
+class DeviseMailer < Devise::Mailer
+  def confirmation_instructions(record, token, opts = {})
+    update_mail_subject(super)
+  end
+
+  def reset_password_instructions(record, token, opts = {})
+    update_mail_subject(super)
+  end
+
+  def unlock_instructions(record, token, opts = {})
+    update_mail_subject(super)
+  end
+
+  def email_changed(record, opts = {})
+    update_mail_subject(super)
+  end
+
+  def password_change(record, opts = {})
+    update_mail_subject(super)
+  end
+
+  private
+
+  # メールタイトルにアプリ名を追加
+  def update_mail_subject(mail)
+    mail.subject = mail.subject.gsub(/%{app_name}/, t('app_name'))
+    mail
+  end
+end

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,7 @@
-<p>ようこそ <%= @email %>さん!</p>
-<p>以下のリンクからログインしてください。</p>
-<p>ログインページはブックマークしてもらえるようお願いいたします。</p>
-<p><%= link_to t('ログイン'), confirmation_url(@resource, confirmation_token: @token, company_id: @resource.company_id) %></p>
+<p><%= @user.name %> 様</p>
+<p>この度はPulse In CRMにご登録いただきありがとうございます。</p>
+<br></br>
+<p>ログインページは以下のリンクをご参照ください。</p>
+<p>表示されたページをブックマーク、またはお気に入りにご登録の上</p>
+<p>本サイトをご利用いただきますようお願い申し上げます。</p>
+<p><%= link_to t('ログイン'), confirmation_url(@resource, confirmation_token: @token, company_id: @resource.company_id) %></p>　

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -94,5 +94,5 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
-  config.reload_classes_only_on_change = false
+  config.reload_classes_only_on_change = true
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -27,7 +27,7 @@ Devise.setup do |config|
   config.mailer_sender = 'tech_video@gmail.com'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'
@@ -219,7 +219,7 @@ Devise.setup do |config|
   # ==> Configuration for :recoverable
   #
   # Defines which key will be used when recovering the password for an account
-  # config.reset_password_keys = [:email]
+  config.reset_password_keys = [:email]
 
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
@@ -228,7 +228,7 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.
-  # config.sign_in_after_reset_password = true
+  config.sign_in_after_reset_password = true
 
   # ==> Configuration for :encryptable
   # Allow you to use another hashing or encryption algorithm besides bcrypt (default).

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,18 @@
+ja:
+  devise:
+    mailer:
+      confirmation_instructions:
+        subject: "【PulseIn CRM】ユーザー登録完了のお知らせ"
+        admin_user_subject: "【%{app_name} Admin】メールアドレス確認のお願い"
+      email_changed:
+        subject: "【PulseIn CRM】メールアドレス変更完了のお知らせ"
+        admin_user_subject: "【%{app_name} Admin】メールアドレス変更完了のお知らせ"
+      reset_password_instructions:
+        subject: "【PulseIn CRM】パスワード再設定方法のお知らせ"
+        admin_user_subject: "【%{app_name} Admin】パスワード再設定方法のお知らせ"
+      password_change:
+        subject: "【PulseIn CRM】パスワード変更完了のお知らせ"
+        admin_user_subject: "【%{app_name} Admin】パスワード変更完了のお知らせ"
+      unlock_instructions:
+        subject: "【PulseIn CRM】アカウントロックのお知らせ"
+        admin_user_subject: "【%{app_name} Admin】アカウントロックのお知らせ"

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -73,7 +73,7 @@ ja:
         action: メールアドレスの確認
         greeting: "%{recipient}様"
         instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
-        subject: メールアドレス確認メール
+        subject: アカウント認証メール
       email_changed:
         greeting: こんにちは、%{recipient}様。
         message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
@@ -177,7 +177,7 @@ ja:
         action: メールアドレスの確認
         greeting: "%{recipient}様"
         instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
-        subject: メールアドレス確認メール
+        subject: アカウント認証メール
       email_changed:
         greeting: こんにちは、%{recipient}様。
         message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,6 @@
 ---
 ja:
+  app_name: "PulseInCRM" 
   activerecord:
     errors:
       messages:


### PR DESCRIPTION
### 概要
メール認証文言の変更（アカウント登録完了に関する）

### タスク
- [ ] なし
- [x] あり (https://trello.com/c/MjxgwzH0)

### 実装内容・手法
アカウント登録完了後に、ユーザーに届くメールを下記の通り、_実装内容や、問題の解決手法を記述する_
主な変更点：
・件名（どの認証メールか具体的にするとともにアプリ名を追加）
・本文（アドレス名から登録者名に変更）、日本語の微調整

![アカ新規登録](https://user-images.githubusercontent.com/77308890/162667702-7d1633d2-2f36-4ee7-885c-925a84d26327.png)