### PR TITLE
User validation

### DIFF
--- a/app/controllers/users/base.rb
+++ b/app/controllers/users/base.rb
@@ -24,21 +24,21 @@ module Users
 
     # お問い合わせ内容の閲覧制限
     def inquiry_browse_access
-      if current_user.role_other? || current_user.access_authorization.inquiry_browse == false
+      if current_user.role_other? || !current_user.access_authorization.inquiry_browse?
         redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' }
       end
     end
 
     # お問い合わせ内容返信の制限
     def inquiry_reply_access
-      if current_user.role_other? || current_user.access_authorization.inquiry_reply == false
+      if current_user.role_other? || !current_user.access_authorization.inquiry_reply?
         redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' }
       end
     end
 
     # お問い合わせフォーム項目設定の制限
     def inquiry_form_setting_access
-      if current_user.role_other? || current_user.access_authorization.inquiry_form_setting == false
+      if current_user.role_other? || !current_user.access_authorization.inquiry_form_setting?
         redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' }
       end
     end

--- a/app/controllers/users/base.rb
+++ b/app/controllers/users/base.rb
@@ -24,24 +24,23 @@ module Users
 
     # お問い合わせ内容の閲覧制限
     def inquiry_browse_access
-      if current_user.role_other?
-        redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' } unless current_user.access_authorization.inquiry_browse
+      if current_user.role_other? || current_user.access_authorization.inquiry_browse == false
+        redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' }
       end
     end
 
     # お問い合わせ内容返信の制限
     def inquiry_reply_access
-      if current_user.role_other?
-        redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' } unless current_user.access_authorization.inquiry_reply
+      if current_user.role_other? || current_user.access_authorization.inquiry_reply == false
+        redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' }
       end
     end
 
     # お問い合わせフォーム項目設定の制限
     def inquiry_form_setting_access
-      if current_user.role_other?
-        redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' } unless current_user.access_authorization.inquiry_form_setting
+      if current_user.role_other? || current_user.access_authorization.inquiry_form_setting == false
+        redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' }
       end
     end
-    
   end
 end

--- a/app/controllers/users/base.rb
+++ b/app/controllers/users/base.rb
@@ -21,5 +21,27 @@ module Users
     def user_other_access
       redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' } if current_user.role_other?
     end
+
+    # お問い合わせ内容の閲覧制限
+    def inquiry_browse_access
+      if current_user.role_other?
+        redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' } unless current_user.access_authorization.inquiry_browse
+      end
+    end
+
+    # お問い合わせ内容返信の制限
+    def inquiry_reply_access
+      if current_user.role_other?
+        redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' } unless current_user.access_authorization.inquiry_reply
+      end
+    end
+
+    # お問い合わせフォーム項目設定の制限
+    def inquiry_form_setting_access
+      if current_user.role_other?
+        redirect_to users_dash_boards_path, flash: { danger: 'アクセス権限がありません' } unless current_user.access_authorization.inquiry_form_setting
+      end
+    end
+    
   end
 end

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -45,7 +45,7 @@ class Users::UsersController < Users::Base
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation,
       access_authorization_attributes: %i[
-        id inquiry_browse inqury_reply inqury_form_setting
+        id inquiry_browse inquiry_reply inquiry_form_setting
       ]
     ).merge(role: 0)
   end

--- a/app/views/users/users/_form.html.erb
+++ b/app/views/users/users/_form.html.erb
@@ -18,12 +18,12 @@
     <%= access_auth.label :inquiry_browse %>
   </div>
   <div>
-    <%= access_auth.check_box :inqury_reply %>
-    <%= access_auth.label :inqury_reply %>
+    <%= access_auth.check_box :inquiry_reply %>
+    <%= access_auth.label :inquiry_reply %>
   </div>
   <div>
-    <%= access_auth.check_box :inqury_form_setting %>
-    <%= access_auth.label :inqury_form_setting %>
+    <%= access_auth.check_box :inquiry_form_setting %>
+    <%= access_auth.label :inquiry_form_setting %>
   </div>
 <% end %>
 <br>

--- a/app/views/users/users/show.html.erb
+++ b/app/views/users/users/show.html.erb
@@ -17,12 +17,12 @@
           <td><%= t("access_authorization.#{@user.access_authorization.inquiry_browse}") %></td>
         </tr>
         <tr>
-          <th><%= AccessAuthorization.human_attribute_name(:inqury_reply) %></th>
-          <td><%= t("access_authorization.#{@user.access_authorization.inqury_reply}") %></td>
+          <th><%= AccessAuthorization.human_attribute_name(:inquiry_reply) %></th>
+          <td><%= t("access_authorization.#{@user.access_authorization.inquiry_reply}") %></td>
         </tr>
         <tr>
-          <th><%= AccessAuthorization.human_attribute_name(:inqury_form_setting) %></th>
-          <td><%= t("access_authorization.#{@user.access_authorization.inqury_form_setting}") %></td>
+          <th><%= AccessAuthorization.human_attribute_name(:inquiry_form_setting) %></th>
+          <td><%= t("access_authorization.#{@user.access_authorization.inquiry_form_setting}") %></td>
         </tr>
       </tbody>
     </table>

--- a/config/locales/model_ja.yml
+++ b/config/locales/model_ja.yml
@@ -9,8 +9,8 @@ ja:
     attributes:
       access_authorization:
         inquiry_browse: 問い合わせ閲覧
-        inqury_reply: 問い合わせ返信
-        inqury_form_setting: 問い合わせフォーム項目設定
+        inquiry_reply: 問い合わせ返信
+        inquiry_form_setting: 問い合わせフォーム項目設定
       inquiry:
         status:
           unread: 未読

--- a/db/migrate/20220331124044_create_access_authorizations.rb
+++ b/db/migrate/20220331124044_create_access_authorizations.rb
@@ -2,8 +2,8 @@ class CreateAccessAuthorizations < ActiveRecord::Migration[6.1]
   def change
     create_table :access_authorizations do |t|
       t.boolean :inquiry_browse
-      t.boolean :inqury_reply
-      t.boolean :inqury_form_setting
+      t.boolean :inquiry_reply
+      t.boolean :inquiry_form_setting
       t.string :user_id, null: false
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema.define(version: 2022_04_09_123621) do
 
   create_table "access_authorizations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.boolean "inquiry_browse"
-    t.boolean "inqury_reply"
-    t.boolean "inqury_form_setting"
+    t.boolean "inquiry_reply"
+    t.boolean "inquiry_form_setting"
     t.string "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/factories/access_authorizations.rb
+++ b/spec/factories/access_authorizations.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :access_authorization do
     inquiry_browse { true }
-    inqury_reply { true }
-    inqury_form_setting { true }
+    inquiry_reply { true }
+    inquiry_form_setting { true }
     user
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe 'InquiryReplies', type: :system do
           fill_in 'user[password_confirmation]', with: 'Password12110807'
 
           check 'user[access_authorization_attributes][inquiry_browse]'
-          check 'user[access_authorization_attributes][inqury_reply]'
-          check 'user[access_authorization_attributes][inqury_form_setting]'
+          check 'user[access_authorization_attributes][inquiry_reply]'
+          check 'user[access_authorization_attributes][inquiry_form_setting]'
 
           click_button '登録'
 


### PR DESCRIPTION
概要
・User追加時に登録した権限でアクセス制限をかける

タスク
[] なし
 あり https://trello.com/c/xFWuIHQe/39-user追加時に登録した権限でアクセス制限をかける
実装内容・手法
・ログイン中のUserがアクセス権限のないページにアクセスしたら「アクセス権限がありません。」というフラッシュメッセージと共にdashboardに遷移させるメソッドをaccess_authorizationモデルに作成

・カラム名を「inquiry」に統一

